### PR TITLE
Added GET /users/id/habits/habitId endpoint

### DIFF
--- a/src/server/api/users.ts
+++ b/src/server/api/users.ts
@@ -39,6 +39,33 @@ usersRouter.get("/:id/habits", requireUser, async (req, res, next): Promise<void
     }
 })
 
+// GET /api/users/:id/habits/:habitId
+usersRouter.get("/:id/habits/:habitId", requireUser, async (req, res, next): Promise<void> => {
+    const ownerId = Number(req.params.id)
+    const habitId = Number(req.params.habitId)
+
+    try {
+        const habit = await prisma.habit.findUnique({
+            where: {
+                ownerId: ownerId,
+                id: habitId
+            },
+            include: {
+                routine: true,
+                checkIn: {
+                    select: {
+                        dayOfTheWeek: true
+                    }
+                }
+            }
+        })
+        res.send({ habit})
+    } catch(e) {
+
+    }
+})
+
+
 // POST /api/users/:id/habits
 usersRouter.post("/:id/habits", requireUser, async (req, res, next): Promise<void> => {
     if (req.user) {


### PR DESCRIPTION
Closes #106 

This is for use with a single habit query (`getHabitById`).

Testing in Postman was successful:
![Screen Shot 2024-01-06 at 14 26 47](https://github.com/dyazdani/trac/assets/99094815/4947e55b-20ca-44b1-815a-209de0c2503f)
