### PR TITLE
Added `deleteKnockUser` mutation

### DIFF
--- a/src/client/features/api.tsx
+++ b/src/client/features/api.tsx
@@ -2,9 +2,7 @@ import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 import { RootState } from '../app/store.js';
 import { Habit } from '@prisma/client';
 import { CreateHabitReqBody, UpdateHabitReqBody, HabitWithDetails } from '../../types/index.js';
-import { Knock } from '@knocklabs/node';
 import { User as KnockUser } from '@knocklabs/node';
-import { User as PrismaUser } from '@prisma/client'
 
 // Define a service using a base URL and expected endpoints
 export const api = createApi({
@@ -21,7 +19,7 @@ export const api = createApi({
     }),
     tagTypes: ['CurrentUser', 'Routine', 'CheckIn', 'Habit', 'User', 'KnockUser'],
     endpoints: (builder) => ({
-      register: builder.mutation<{user: PrismaUser}, {email: string, username: string, password: string}>({
+      register: builder.mutation({
         query: ({ email, username, password }) => ({
           url: "auth/register",
           method: "POST",


### PR DESCRIPTION
Closes #130 

Made a temporary test button that logged the success message if the user was deleted from Knock (I did not keep the test button after testing):

https://github.com/dyazdani/trac/assets/99094815/3ea56c51-ddff-43a3-a595-c33678a2689d

No more Users in Knock:
![Screen Shot 2024-01-12 at 01 59 48](https://github.com/dyazdani/trac/assets/99094815/af6e08da-173d-4054-893c-1bb8b4ce63ad)
