### PR TITLE
Fixed syntax error in `vite.config.ts`

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,10 +12,10 @@ export default defineConfig({
     'process.env': process.env
   },
   optimizeDeps: {
+    exclude: ['chunk-KXW2NGCQ.js'],
     esbuildOptions: {
       // Enable esbuild polyfill plugins
-      plugins: [NodeModulesPolyfillPlugin()],
-      exclude: ['chunk-KXW2NGCQ.js']
+      plugins: [NodeModulesPolyfillPlugin()]
     },
   },
   build: {


### PR DESCRIPTION
The `exclude` key and value were in the wrong place in `optimizeDeps`.