### PR TITLE
Added PUT /api/notifications/schedules endpoint

### DIFF
--- a/src/server/api/notifications.ts
+++ b/src/server/api/notifications.ts
@@ -1,5 +1,5 @@
 import express from "express";
-import { Knock, RepeatFrequency } from "@knocklabs/node";
+import { DaysOfWeek, Knock, RepeatFrequency } from "@knocklabs/node";
 import requireUser from "../../utils/requireUser.js";
 import { CreateScheduleReqBody } from "../../types/index.js";
 
@@ -40,6 +40,28 @@ notificationsRouter.post("/schedules", requireUser, async (req, res, next) => {
         }
     }
 } )
+
+// PUT /api/notifications/schedules
+notificationsRouter.put("/schedules", requireUser, async (req, res, next) => {
+    if (req.user) {
+        try {
+            const { scheduleIds, days }: {scheduleIds: string[], days: DaysOfWeek[]} = req.body;
+            const updatedSchedules = await knock.workflows.updateSchedules({
+                schedule_ids: scheduleIds,
+                repeats: [
+                    {
+                        frequency: RepeatFrequency.Weekly,
+                        days
+                    }
+                ]
+            })
+
+            res.send({ updatedSchedules });
+        } catch (e) {
+            next(e);
+        }
+    }
+})
 
 // DELETE /api/notifications/users/:user_id
 notificationsRouter.delete("/users/:user_id", requireUser, async (req, res, next) => {


### PR DESCRIPTION
Closes #146

Endpoint for updating schedules in Knock. Has the ability to update more than one schedule. It is set up to just change which days of the week there will be weekly reminders because those are the types of schedules we have planned for our app at this point.

Succes in Postman:
![Screen Shot 2024-01-19 at 10 00 11](https://github.com/dyazdani/trac/assets/99094815/b25d6a69-1c4e-40b4-8afe-6cb83af351ae)

The days of the week for the schedule in Knock switched from Mon and Wed, to just Mon:
![Screen Shot 2024-01-19 at 10 02 48](https://github.com/dyazdani/trac/assets/99094815/8a626a55-6de7-4669-a645-94b465914d96)
