### PR TITLE
Fixing bug in `updateSchedule` call in `UpdateHabitButton.tsx`

### DIFF
--- a/src/client/features/api.tsx
+++ b/src/client/features/api.tsx
@@ -1,6 +1,6 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 import { RootState } from '../app/store.js';
-import { Habit, StatusReport } from '@prisma/client';
+import { CheckIn, Habit, Routine, StatusReport } from '@prisma/client';
 import { CreateHabitReqBody, UpdateHabitReqBody, HabitWithDetails, SendStatusReportMutationArgs } from '../../types/index.js';
 import { DaysOfWeek, Schedule } from '@knocklabs/node';
 import { User as KnockUser } from '@knocklabs/node';
@@ -122,8 +122,7 @@ export const api = createApi({
         }),
         invalidatesTags: ["Habit"],
       }),
-      //TODO: the return type could be switched to HabitWithDetails to include relations
-      updateHabit: builder.mutation<{habit: Habit}, {id: number, habitId: number, newHabit: UpdateHabitReqBody}>({
+      updateHabit: builder.mutation<{habit: Habit, routine: Routine, checkIn: CheckIn}, {id: number, habitId: number, newHabit: UpdateHabitReqBody}>({
         query: ({id, habitId, newHabit}) => ({
           url: `users/${id}/habits`,
           method: "PUT",


### PR DESCRIPTION
Knock's server apparently throws a 500 exception if you try to update with the same information that is already in the schedule. I was getting the error when I was only editing the name or routine days of the habit, which was trying to update the schedule with the check-in day being the same. I changed it so that it only makes a call to Knock when the check-in day changes, which is the only information that the updateSchedule endpoint is concerned about.

