### PR TITLE
Added timezone property to identify user endpoint request body for Knock

### DIFF
--- a/src/server/api/notifications.ts
+++ b/src/server/api/notifications.ts
@@ -106,7 +106,8 @@ notificationsRouter.put("/users/:user_id", requireUser, async (req, res, next): 
             
             const user = await knock.users.identify(id, {
                 email,
-                username
+                username,
+                timezone: Intl.DateTimeFormat().resolvedOptions().timeZone
             })
             res.send({user});
         } catch (e) {


### PR DESCRIPTION
This makes the Knock notifications for schedules occur in the user's local time, versus UTC.

![Screen Shot 2024-02-08 at 10 27 06](https://github.com/dyazdani/trac/assets/99094815/8496163e-7fe2-4ca2-a94d-b6e68dab7c6a)
![Screen Shot 2024-02-08 at 10 37 49](https://github.com/dyazdani/trac/assets/99094815/8b2c2e75-d872-453b-9364-4b12d06e4039)
![Screen Shot 2024-02-08 at 10 37 07](https://github.com/dyazdani/trac/assets/99094815/56ccf983-bec5-4e23-b90f-eb3de3fff9ea)
