### PR TITLE
Corrected labels in dashboard legend

### DIFF
--- a/src/client/components/Dashboard.tsx
+++ b/src/client/components/Dashboard.tsx
@@ -60,11 +60,11 @@ const Dashboard = () => {
               <HStack>
                 <HStack spacing={0}>
                   <Image src="/images/trac_today_icon.png" alt="purple circle indicating today" p={0} />
-                  <Text>= today</Text>
+                  <Text>= Check-In Day</Text>
                 </HStack>
                 <HStack spacing={0}>
                   <Image src="images/diamond-pink.png" alt="yellow diamond indicating check-in day" maxW="45px" p="10px"/>
-                  <Text>= check-in day</Text>
+                  <Text>= Today</Text>
                 </HStack>
               </HStack>
             </Box>


### PR DESCRIPTION
Fixed the labeling so that it is correct (the labels had been accidentally switched):
![Screen Shot 2024-02-09 at 09 54 56](https://github.com/dyazdani/trac/assets/99094815/07aeb577-d55d-4790-83af-1a2f6a314467)
