### PR TITLE
Fixed bug that reordered `HabitCard` components in `Milestone.tsx` whenever top `HabitCard` `ToggleButton` was clicked

### DIFF
--- a/src/client/components/Milestone.tsx
+++ b/src/client/components/Milestone.tsx
@@ -80,7 +80,9 @@ const Milestone = ({milestone}: MilestoneProps) => {
             >
           <CardBody>
           <Accordion defaultIndex={[0]} allowMultiple>
-            {milestone.habits.map(habit => {
+            {[...milestone.habits].sort((a, b) =>  
+                    a.name.localeCompare(b.name, "en", {ignorePunctuation: true}))
+            .map(habit => {
                 return (
                     <AccordionItem
                         key={habit.id}


### PR DESCRIPTION
Closes #298 

Reordering no longer happens when clicking toggle buttons:

https://github.com/dyazdani/trac/assets/99094815/a1304be6-0a73-45ac-b8e4-898c7bb10d06

