### PR TITLE
Fixed bug that made environment variables undefined

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,10 @@ import { nodePolyfills } from 'vite-plugin-node-polyfills';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  define: {
+    // to use environment variables, otherwise they are all undefined
+    'process.env': process.env
+  },
   plugins: [
     react(),
     // to fix bug accessing Vite Node dependencies (was logging TypeError: 'Bst.inherits is not a function')


### PR DESCRIPTION
Closes #312 

Added back `define` object in `vite.config.ts` with property `'process.env'` having a value of `process.env`. This was present before, but was accidentally deleted in a previous commit.