### PR TITLE
Fix `isInvalid` styling in `RegisterForm`

### DIFF
--- a/src/client/components/RegisterForm.tsx
+++ b/src/client/components/RegisterForm.tsx
@@ -136,7 +136,7 @@ const RegisterForm: React.FC<RegisterFormProps> = ({handleLinkClick}) => {
                         </FormControl>
                         <FormControl
                             isRequired
-                            isInvalid={isPasswordInvalid}
+                            isInvalid={isPasswordInvalid ? getPasswordValidation(password).isTooWeak : false}
                             isDisabled={
                                 isLoading ||
                                 isKnockLoading ||


### PR DESCRIPTION
Closes #303 


isInvalid red border styling now goes away on password once the password is valid after first unsuccessful submit:


Uploading Screen Recording 2024-02-14 at 12.32.41.mov…

