### PR TITLE
Fixed error messages not all displaying when they should

### DIFF
--- a/src/client/components/RegisterForm.tsx
+++ b/src/client/components/RegisterForm.tsx
@@ -69,11 +69,6 @@ const RegisterForm: React.FC<RegisterFormProps> = ({handleLinkClick}) => {
         try {
             if (getPasswordValidation(password).isTooWeak) {
                 setIsPasswordInvalid(true);
-                return;
-            }
-    
-            if (password !== confirmPassword) {
-                return;
             }
             
             if (!isUsersLoading) {
@@ -88,8 +83,7 @@ const RegisterForm: React.FC<RegisterFormProps> = ({handleLinkClick}) => {
                         setIsUsernameTaken(true);
                     }
 
-                    if (isUserEmailTaken || isUserUsernameTaken) {
-                        setIsPasswordInvalid(false);
+                    if (isUserEmailTaken || isUserUsernameTaken || password !== confirmPassword || getPasswordValidation(password).isTooWeak) {
                         return
                     }
                 }


### PR DESCRIPTION
Now when the username and email error messages underneath input fields will display on submit when the password is invalid.