### PR TITLE
Status report text now updates without refresh

### DIFF
--- a/src/client/components/StatusReportFormButton.tsx
+++ b/src/client/components/StatusReportFormButton.tsx
@@ -70,7 +70,13 @@ const StatusReportFormButton = ({habit}: StatusReportFormButtonProps) => {
             aria-label='send-status-report-form'
             fontSize='20px'
             border="2mm ridge rgba(255,215,0, .6)"
-            onClick={onOpen}
+            onClick={(e) => {
+                e.preventDefault();
+                if (!message) {
+                    setMessage(getDefaultStatusReportMessage(habit, currentUser.username))
+                }
+                onOpen();
+            }}
             >
                 Send Status Report
             </Button>
@@ -144,7 +150,11 @@ const StatusReportFormButton = ({habit}: StatusReportFormButtonProps) => {
                             variant="outline" 
                             colorScheme='teal' 
                             mr={3} 
-                            onClick={onClose}
+                            onClick={(e) => {
+                                e.preventDefault();
+                                onClose();
+                                setMessage("");
+                            }}
                         >
                             Cancel
                         </Button>


### PR DESCRIPTION
Closes #291 

It was a local state management issue. The local state now uses the helper function to obtain new text whenever the component reopens.


https://github.com/dyazdani/trac/assets/99094815/befadef9-1d36-4888-b69c-fa6bf1e5b1aa

