### PR TITLE
Accordion collapse bug

### DIFF
--- a/src/client/components/Milestone.tsx
+++ b/src/client/components/Milestone.tsx
@@ -141,7 +141,9 @@ const Milestone = ({milestone}: MilestoneProps) => {
                 <Text fontSize="xl">You currently have no Habits for this Goal.</Text> : 
                 ""
               }
-            <Accordion defaultIndex={[0]} allowMultiple >
+            <Accordion
+                allowMultiple
+            >
                 {[...milestone.habits].sort((a, b) => new Date(b.dateCreated).getTime() - new Date(a.dateCreated).getTime())
                     .map(habit => {
                     return (


### PR DESCRIPTION
Closes #418 

Now the accordion items can collapse properly. They no longer open to the first item upon render.