### PR TITLE
Habit week view changes

### DIFF
--- a/src/client/components/HabitCard.tsx
+++ b/src/client/components/HabitCard.tsx
@@ -18,7 +18,6 @@ import {
   Button,
   Grid,
   GridItem,
-  Tooltip,
 } from "@chakra-ui/react";
 import { motion } from 'framer-motion';
 import { 
@@ -334,11 +333,6 @@ const HabitCard = ({ habit, milestone }: HabitProps) => {
                     </GridItem>
                     {!isDateOutOfRange(new Date(habit.dateCreated), new Date(milestone.dueDate), day) ? 
                     (
-                      <Tooltip
-                      isDisabled={!isOutOfRange}
-                      label="Cannot complete dates before Habit start or after today"
-                      placement="bottom"
-                    >
                       <GridItem
                         padding={".2vw"}
                         borderBottom={isToday && isHabitRoutineDay(habit, day) ? "2px solid #3a3c3c" : {}}
@@ -358,7 +352,6 @@ const HabitCard = ({ habit, milestone }: HabitProps) => {
 
                       />
                       </GridItem>
-                    </Tooltip>
                     ) : ""
                   }
                     


### PR DESCRIPTION
Closes #447 
Closes #391 

Habit displays weeks from habit creation week to due date week. Checkboxes don't display before habit creation and after milestone due date. It the date is after today, the checkbox is disabled. Only habit routine days have checkboxes. Dates from habit creation through today are labeled in black, Everything think else is gray.


https://github.com/dyazdani/trac/assets/99094815/aaae0bcc-fb93-4017-875e-10021a073711

