### PR TITLE
Revise `HabitCard` Design

### DIFF
--- a/src/client/components/HabitCard.tsx
+++ b/src/client/components/HabitCard.tsx
@@ -187,7 +187,7 @@ const HabitCard = ({ habit, milestone }: HabitProps) => {
         >
           <Heading 
             sx={{ marginRight: "auto" }} 
-            as="h3"
+            as="h4"
             size="md"
             color={milestone.isCanceled || milestone.isCompleted ? "darkslategray.400" : ""}
           >

--- a/src/client/components/Milestone.tsx
+++ b/src/client/components/Milestone.tsx
@@ -239,8 +239,11 @@ const Milestone = ({milestone}: MilestoneProps) => {
                         >
                             {({ isExpanded }) => (
                                 <>
-                                    <h2>
-                                    <AccordionButton>
+                                    <AccordionButton
+                                        _focusVisible={{
+                                            borderRadius: "20px"
+                                        }}
+                                    >
                                         <Box 
                                             as="span" 
                                             flex='1' 
@@ -251,7 +254,6 @@ const Milestone = ({milestone}: MilestoneProps) => {
                                         </Box>
                                         <AccordionIcon />
                                     </AccordionButton>
-                                    </h2>
                                     <AccordionPanel 
                                         padding="0"
                                     >


### PR DESCRIPTION
Closes #518 
Closes #519 
Closes #438 

Removed nested card look from `HabitCard` design. Reformatted and gave title underline.


![Screen Shot 2024-03-11 at 14 50 20](https://github.com/dyazdani/trac/assets/99094815/133ccf08-6b9b-4531-8ff6-ec08a5392e96)

![Screen Shot 2024-03-11 at 11 02 35](https://github.com/dyazdani/trac/assets/99094815/a9d1ec8f-6965-4d11-afda-b3372e64d5a5)
