### PR TITLE
Switch Current Week View in `HabitCard`

### DIFF
--- a/src/client/components/HabitCard.tsx
+++ b/src/client/components/HabitCard.tsx
@@ -154,7 +154,15 @@ const HabitCard = ({ habit, milestone }: HabitProps) => {
       thisWeek.push(new Date(previousDay.setDate(previousDayOfTheMonth + 1)))
     }
     setCurrentWeek(thisWeek);
-  } 
+  } else if (currentWeek.every(date => date.setHours(0, 0, 0, 0) > new Date(milestone.dueDate).setHours(0, 0, 0, 0))) {
+    let targetWeek = getPreviousWeek(currentWeek);
+
+    while (targetWeek.every(date => date.setHours(0, 0, 0, 0) > new Date(milestone.dueDate).setHours(0, 0, 0, 0))) {
+      targetWeek = getPreviousWeek(targetWeek);
+    }
+
+    setCurrentWeek(targetWeek);
+  }
 
   // Function for left arrow button that displays previous week
   const handleLeftArrowClick = () => {


### PR DESCRIPTION
Closes #511 

Now switches `HabitCard` weekly view to the current week after Milestone due date is changed and it the weekly view is ahead of new due date.


https://github.com/dyazdani/trac/assets/99094815/5abb9824-ac70-4cf8-a448-de78ad611d5f

