### PR TITLE
Refactored sending user timezone to Knock

### DIFF
--- a/src/client/components/RegisterForm.tsx
+++ b/src/client/components/RegisterForm.tsx
@@ -24,7 +24,6 @@ import {
     GridItem,
     LinkBox,
     LinkOverlay,
-    Heading
 } from "@chakra-ui/react";
 import { Link as ReactRouterLink } from "react-router-dom";
 import { 
@@ -81,12 +80,13 @@ const RegisterForm = () => {
 
     const handleSubmit = async () => {
         try {
+            const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
             const response = await register({ email, username, password }).unwrap();
 
             console.log(response)
 
             if (response.user) {
-                const knockUser = await identifyUser({id: String(response.user?.id), email, username})
+                const knockUser = await identifyUser({id: String(response.user?.id), email, username, timezone})
                 console.log(knockUser)
             } 
 

--- a/src/client/features/api.tsx
+++ b/src/client/features/api.tsx
@@ -113,13 +113,14 @@ export const api = createApi({
         }),
         invalidatesTags: ["KnockUser"],
       }),
-      identifyUser: builder.mutation<{user: KnockUser}, {id: string, email: string, username: string}>({
-        query: ({id, email, username}) => ({
+      identifyUser: builder.mutation<{user: KnockUser}, {id: string, email: string, username: string, timezone: string}>({
+        query: ({id, email, username, timezone}) => ({
           url: `/notifications/users/${id}`,
           method: "PUT",
           body: {
             email,
-            username
+            username,
+            timezone
           }
         }),
         invalidatesTags: ["KnockUser"]

--- a/src/server/api/notifications.ts
+++ b/src/server/api/notifications.ts
@@ -104,12 +104,12 @@ notificationsRouter.put("/users/:user_id", requireUser, async (req, res, next): 
     if (req.user) {
         try {
             const id = req.params.user_id
-            const { email, username } = req.body;
+            const { email, username, timezone } = req.body;
             
             const user = await knock.users.identify(id, {
                 email,
                 username,
-                timezone: Intl.DateTimeFormat().resolvedOptions().timeZone
+                timezone
             })
             res.send({user});
         } catch (e) {


### PR DESCRIPTION
TZ string now obtained from the front end before mutation triggered instead of at the express router. This will hopefully fix issue of timezone not being valid in Knock in production environment, but have to test it by merging it to main and deploying it on Render.

![Screen Shot 2024-03-26 at 12 17 05](https://github.com/dyazdani/trac/assets/99094815/964da278-e1b1-461a-b5d3-37589f331f32)

anddddddd...

...it worked!

![Screen Shot 2024-03-26 at 12 23 13](https://github.com/dyazdani/trac/assets/99094815/6f3f928b-5be0-4dd2-9247-9a47833abb74)
