### PR TITLE
Added time to PUT /api/notifications/schedules endpoint

### DIFF
--- a/src/server/api/notifications.ts
+++ b/src/server/api/notifications.ts
@@ -53,7 +53,9 @@ notificationsRouter.put("/schedules", requireUser, async (req, res, next) => {
                 repeats: [
                     {
                         frequency: RepeatFrequency.Weekly,
-                        days
+                        days,
+                        hours: 5,
+                        minutes: 0
                     }
                 ]
             })


### PR DESCRIPTION
Added time setting for PUT /api/notifications/schedules endpoint in `notificationsRouter.ts` so that the time stays the same when a Check-In Day is changed.