### PR TITLE
Corrected logo artist credit info

### DIFF
--- a/src/client/components/ArtistCredit.tsx
+++ b/src/client/components/ArtistCredit.tsx
@@ -24,10 +24,10 @@ const ArtistCredit = ({ textColor }: ArtistCreditProps) => {
               color={textColor} 
             >
             <Link 
-              href="https://thenounproject.com/icon/mountain-120042/" 
+              href="https://thenounproject.com/icon/mountain-flag-119605" 
               isExternal
             >
-              Mountain
+              Mountain Flag
               <ExternalLinkIcon 
                 mr=".5em" 
                 boxSize=".9em" 


### PR DESCRIPTION
Closes #600 

Corrected logo name from "Mountain" to "Mountain Flag" and linked to correct page.
![Screen Shot 2024-06-27 at 16 07 13](https://github.com/dyazdani/trac/assets/99094815/b6dd9abc-0bdc-4966-a2a5-94e79d7e6522)
![Screen Shot 2024-06-27 at 16 07 22](https://github.com/dyazdani/trac/assets/99094815/364d268f-f9a2-4257-a8a1-9e63f2d89290)
