### PR TITLE
Fixed issue of duplicate mutations being triggered on `ToggleButton` with multiple rapid clicks

### DIFF
--- a/src/client/app/hooks.ts
+++ b/src/client/app/hooks.ts
@@ -1,7 +1,52 @@
-import { useDispatch, useSelector } from 'react-redux'
+import { 
+    useRef, 
+    useEffect 
+} from "react";
+import { 
+    useDispatch, 
+    useSelector 
+} from 'react-redux'
 import type { TypedUseSelectorHook } from 'react-redux'
-import type { RootState, AppDispatch } from './store.js'
+import type { 
+    RootState, 
+    AppDispatch 
+} from './store.js'
 
 // Use throughout your app instead of plain `useDispatch` and `useSelector`
 export const useAppDispatch: () => AppDispatch = useDispatch
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector
+
+
+// Hook to create a debounced version of a given function
+type Timer = ReturnType<typeof setTimeout>;
+type SomeFunction = (...args: any[]) => void;
+/**
+ *
+ * @param func The original, non debounced function (You can pass any number of args to it)
+ * @param delay The delay (in ms) for the function to return
+ * @returns The debounced function, which will run only if the debounced function has not been called in the last (delay) ms
+ */
+
+export function useDebounce<Func extends SomeFunction>(
+  func: Func,
+  delay = 1000
+) {
+  const timer = useRef<Timer>();
+
+  useEffect(() => {
+    return () => {
+      if (!timer.current) return;
+      clearTimeout(timer.current);
+    };
+  }, []);
+
+  const debouncedFunction = ((...args) => {
+    const newTimer = setTimeout(() => {
+      func(...args);
+    }, delay);
+    clearTimeout(timer.current);
+    timer.current = newTimer;
+  }) as Func;
+
+  return debouncedFunction;
+}

--- a/src/client/components/HabitCard.tsx
+++ b/src/client/components/HabitCard.tsx
@@ -73,6 +73,7 @@ export const SEVEN_DAYS_IN_MILLISECONDS = 7 * 24 * 60 * 60 * 1000;
 
 const HabitCard = ({ habit, milestone }: HabitProps) => {
   const [currentWeek, setCurrentWeek] = useState<Date[]>(getCurrentWeek(habit, milestone))
+  const [isToggleLoading, setIsToggleLoading] = useState(false);
 
   const toast = useToast();
   
@@ -503,12 +504,19 @@ const HabitCard = ({ habit, milestone }: HabitProps) => {
                       colSpan={1} 
                       rowStart={4}
                       textAlign="center"
+                      onClickCapture={isToggleLoading ? 
+                        (e) => {
+                        e.stopPropagation();
+                      } : undefined
+                    }
                     > 
                     <ToggleButton
                       milestone={milestone}
                       date={day}
                       habit={habit}
                       isOutOfRange={isOutOfRange}
+                      isToggleLoading={isToggleLoading}
+                      setIsToggleLoading={setIsToggleLoading}
                     /> 
                     </GridItem>
                     </> :

--- a/src/client/components/ToggleButton.tsx
+++ b/src/client/components/ToggleButton.tsx
@@ -152,7 +152,7 @@ const ToggleButton = ({
         }
     }
 
-    // const debouncedHandleSubmit = useDebounce(handleSubmit, 500);
+    const debouncedHandleSubmit = useDebounce(handleSubmit, 500);
 
     return (
         isLoading ?
@@ -180,7 +180,7 @@ const ToggleButton = ({
             }}
             onChange={(e) => {
                 e.preventDefault();
-                handleSubmit();
+                debouncedHandleSubmit();
             }}
             isDisabled={ 
                 milestone.isCanceled ||


### PR DESCRIPTION
Closes: #609 

- Debounced version of `handleSubmit` function added to `ToggleButton` checkbox's `onChange` prop to prevent repeat mutation calls. 

- Other `ToggleButton`s are now disabled while mutation's `isLoading` === `true`.

- There is still one minor bug that can trigger one duplicate mutation call, but it is hard to trigger (checkbox has to be clicked at exactly the right time). This bug has an issue created for it with a video of the behavior: #613    
